### PR TITLE
feat: extends affiliate fee functionality

### DIFF
--- a/contracts/Zap.sol
+++ b/contracts/Zap.sol
@@ -47,6 +47,11 @@ struct ZapOutTx {
     uint8 dexIndex;
 }
 
+struct AffiliateData {
+    uint16 fee;
+    uint256 deadline;
+}
+
 /**  
 @title Zap
 @notice Allows to zapIn from an ERC20 or native currency to ERC20 pair
@@ -56,17 +61,16 @@ and zapOut from an ERC20 pair to an ERC20 or native currency
 contract Zap is Ownable, ReentrancyGuard {
     bool public stopped = false; // pause the contract if emergency
     uint16 public protocolFee = 50; // default 0.5% of zap amount protocol fee (range: 0-10000)
-    uint16 public affiliateSplit; // % share of protocol fee 0-100 % (range: 0-10000)
     address public feeTo;
     address public feeToSetter;
     address public immutable nativeCurrencyWrapper;
 
     // set list of supported DEXs for zap
     mapping(uint8 => DEX) public supportedDEXs;
-    // if true, protocol fee is not deducted
+    // if true, protocol fee nor affiliate fee is not deducted
     mapping(address => bool) public feeWhitelist;
     // restrict affiliates
-    mapping(address => bool) public affiliates;
+    mapping(address => AffiliateData) public affiliates;
     // affiliate => token => amount
     mapping(address => mapping(address => uint256)) public affiliateBalance;
     // token => amount
@@ -197,18 +201,17 @@ contract Zap is Ownable, ReentrancyGuard {
     }
 
     /** 
-    @notice Set new affiliate split value
+    @notice Set new fee and deadline for a specific affiliate
+    @param _affiliate The address of the affiliate to update
+    @param _newAffiliateFee The new fee for the affiliate
+    @param _newAffiliateDeadline The new deadline for the affiliate 
     */
-    function setNewAffiliateSplit(uint16 _newAffiliateSplit) external onlyOwner {
-        if (_newAffiliateSplit > 10000) revert ForbiddenValue();
-        affiliateSplit = _newAffiliateSplit;
-    }
+    function setAffiliateData(address _affiliate, uint16 _newAffiliateFee, uint256 _newAffiliateDeadline) external onlyOwner {
+        if (_newAffiliateFee > protocolFee) revert ForbiddenValue();
 
-    /** 
-    @notice Set new affiliate status for specified address
-    */
-    function setAffiliateStatus(address _affiliate, bool _status) external onlyOwner {
-        affiliates[_affiliate] = _status;
+        AffiliateData storage affiliateData = affiliates[_affiliate];
+        affiliateData.fee = _newAffiliateFee;
+        affiliateData.deadline = _newAffiliateDeadline;
     }
 
     /** 
@@ -457,18 +460,20 @@ contract Zap is Ownable, ReentrancyGuard {
     @return totalProtocolFeePortion Total amount of protocol fee taken
     */
     function _subtractProtocolFee(
-        address token,
-        uint256 amount,
+        address token, 
+        uint256 amount, 
         address affiliate
     ) internal returns (uint256 totalProtocolFeePortion) {
         bool whitelisted = feeWhitelist[msg.sender];
         if (!whitelisted && protocolFee > 0) {
             totalProtocolFeePortion = (amount * protocolFee) / 10000;
 
-            if (affiliates[affiliate] && affiliateSplit > 0) {
-                uint256 affiliatePortion = (totalProtocolFeePortion * affiliateSplit) / 10000;
-                affiliateBalance[affiliate][token] = affiliateBalance[affiliate][token] + affiliatePortion;
-                totalAffiliateBalance[token] = totalAffiliateBalance[token] + affiliatePortion;
+            AffiliateData storage affiliateData = affiliates[affiliate];
+            if (affiliateData.fee > 0 && affiliateData.deadline > block.timestamp) {
+                uint256 affiliatePortion = (amount * affiliateData.fee) / 10000;
+                affiliateBalance[affiliate][token] += affiliatePortion;
+                totalAffiliateBalance[token] += affiliatePortion;
+                totalProtocolFeePortion += affiliatePortion;
             }
         }
     }

--- a/test/Zap.test.ts
+++ b/test/Zap.test.ts
@@ -186,8 +186,9 @@ describe.only("Zap", function () {
         zap.connect(impersonated).getSupportedDEX(BigNumber.from(81))
       ).to.be.revertedWith("InvalidRouterOrFactory()")
 
+      // affiliate fee can't be higher than protocol fee
       await expect(
-        zap.connect(owner).setNewAffiliateSplit(BigNumber.from(10001))
+        zap.connect(owner).setAffiliateData(impersonated.address, BigNumber.from(100), BigNumber.from(0))
       ).to.be.revertedWith("ForbiddenValue()")
     })
   })
@@ -268,13 +269,18 @@ describe.only("Zap", function () {
     })
 
     it("set affliate", async function () {
-      const _newAffliateSplit = BigNumber.from(2000)
-      expect(await zap.affiliateSplit()).to.eq(0)
-      await zap.setNewAffiliateSplit(_newAffliateSplit)
-      expect(await zap.affiliateSplit()).to.eq(_newAffliateSplit)
+      const _newAffliateSplit = BigNumber.from(20)
+
+      let affiliateData = await zap.affiliates(impersonated.address);
+      expect(affiliateData["fee"]).to.eq(0)
+
+      await zap.setAffiliateData(impersonated.address, _newAffliateSplit, BigNumber.from(0))
+      affiliateData = await zap.affiliates(impersonated.address);
+      expect(affiliateData["fee"]).to.eq(_newAffliateSplit)
     })
-    it("revert ownable affliateSplit", async function () {
-      await expect(zap.connect(randomSigner).setNewAffiliateSplit(BigNumber.from(2000))).to.be.revertedWith('OnlyOwner()')
+
+    it("revert ownable setAffliateData", async function () {
+      await expect(zap.connect(randomSigner).setAffiliateData(impersonated.address,BigNumber.from(2000),BigNumber.from(0))).to.be.revertedWith('OnlyOwner()')
     })
 
     it("zap in protocol fee on & address is not whitelisted", async function () {
@@ -329,13 +335,9 @@ describe.only("Zap", function () {
 
     it("zap in protocol fee on & address is not whitelisted & affiliate on", async function () {
       const totalAmount = ethers.utils.parseEther("1")
-      const _newAffliateSplit = BigNumber.from(2000)
-      await zap.setNewAffiliateSplit(_newAffliateSplit)
-      const affliateSplit = await zap.affiliateSplit()
-      expect(affliateSplit).to.eq(_newAffliateSplit)
-      await zap.setAffiliateStatus(randomSigner.address, true)
-      expect(await zap.affiliates(randomSigner.address)).to.eq(true)
-      
+      const affliateFee = BigNumber.from(30)
+      await zap.setAffiliateData(randomSigner.address, affliateFee, BigNumber.from(Math.floor(Date.now() / 1000) + 60 * 60))
+
       const protocolFeeForZap = await zap.protocolFee()
       expect(protocolFeeForZap).to.be.above(0)
 
@@ -356,10 +358,11 @@ describe.only("Zap", function () {
       
       const zapTokenBalance = await DXD.balanceOf(zap.address)
       const zapFeeTaken = (totalAmount.mul(protocolFeeForZap)).div(BigNumber.from(10000))
-      expect(zapTokenBalance).to.be.eq(zapFeeTaken)
+      
       const affliateBalance = await zap.affiliateBalance(randomSigner.address, DXD.address)
-      const affliateTaken = (zapFeeTaken.mul(affliateSplit)).div(BigNumber.from(10000))
+      const affliateTaken = (totalAmount.mul(affliateFee)).div(BigNumber.from(10000))
       expect(affliateBalance).to.be.eq(affliateTaken)
+      expect(zapTokenBalance).to.be.eq(zapFeeTaken.add(affliateTaken))
     })
 
 

--- a/test/Zap.test.ts
+++ b/test/Zap.test.ts
@@ -188,7 +188,7 @@ describe.only("Zap", function () {
 
       // affiliate fee can't be higher than protocol fee
       await expect(
-        zap.connect(owner).setAffiliateData(impersonated.address, BigNumber.from(100), BigNumber.from(0))
+        zap.connect(owner).setAffiliateData(impersonated.address, BigNumber.from(100), BigNumber.from(100), BigNumber.from(0))
       ).to.be.revertedWith("ForbiddenValue()")
     })
   })
@@ -272,15 +272,15 @@ describe.only("Zap", function () {
       const _newAffliateSplit = BigNumber.from(20)
 
       let affiliateData = await zap.affiliates(impersonated.address);
-      expect(affiliateData["fee"]).to.eq(0)
+      expect(affiliateData["affiliateFee"]).to.eq(0)
 
-      await zap.setAffiliateData(impersonated.address, _newAffliateSplit, BigNumber.from(0))
+      await zap.setAffiliateData(impersonated.address, _newAffliateSplit, BigNumber.from(20), BigNumber.from(0))
       affiliateData = await zap.affiliates(impersonated.address);
-      expect(affiliateData["fee"]).to.eq(_newAffliateSplit)
+      expect(affiliateData["affiliateFee"]).to.eq(_newAffliateSplit)
     })
 
     it("revert ownable setAffliateData", async function () {
-      await expect(zap.connect(randomSigner).setAffiliateData(impersonated.address,BigNumber.from(2000),BigNumber.from(0))).to.be.revertedWith('OnlyOwner()')
+      await expect(zap.connect(randomSigner).setAffiliateData(impersonated.address,BigNumber.from(2000), BigNumber.from(20),BigNumber.from(0))).to.be.revertedWith('OnlyOwner()')
     })
 
     it("zap in protocol fee on & address is not whitelisted", async function () {
@@ -336,7 +336,8 @@ describe.only("Zap", function () {
     it("zap in protocol fee on & address is not whitelisted & affiliate on", async function () {
       const totalAmount = ethers.utils.parseEther("1")
       const affliateFee = BigNumber.from(30)
-      await zap.setAffiliateData(randomSigner.address, affliateFee, BigNumber.from(Math.floor(Date.now() / 1000) + 60 * 60))
+      const protocolFee = BigNumber.from(50)
+      await zap.setAffiliateData(randomSigner.address, affliateFee, protocolFee, BigNumber.from(Math.floor(Date.now() / 1000) + 60 * 60))
 
       const protocolFeeForZap = await zap.protocolFee()
       expect(protocolFeeForZap).to.be.above(0)
@@ -368,7 +369,8 @@ describe.only("Zap", function () {
     it("zap in protocol fee on & address is not whitelisted & affiliate on but deadline passed", async function () {
       const totalAmount = ethers.utils.parseEther("1")
       const affliateFee = BigNumber.from(30)
-      await zap.setAffiliateData(randomSigner.address, affliateFee, BigNumber.from(Math.floor(Date.now() / 1000) - 60 * 60))
+      const protocolFee = BigNumber.from(50)
+      await zap.setAffiliateData(randomSigner.address, affliateFee, protocolFee, BigNumber.from(Math.floor(Date.now() / 1000) - 60 * 60))
 
       const protocolFeeForZap = await zap.protocolFee()
       expect(protocolFeeForZap).to.be.above(0)


### PR DESCRIPTION
This PR is a proposal taken from #3 that replaces the fixed `affiliateSplit` with a more flexible per-address fee+deadline structure. It also changes the way affiliate fees are taken, now they are taken from the total amount and not from the protocol fee, but they can't be higher than protocol fee.

Breaking changes:

- `affiliates` mapping now stores `AffiliateData` struct
- `affiliateSplit` storage variable removed
- `setNewAffiliateSplit` replaced with `setAffiliateData`
- `setAffiliateStatus` removed. An affiliate can be deactivated by setting the deadline to anything < `now` through `setAffiliateData`

Tests for `affilliateWithdraw` not added because they are covered by #4 